### PR TITLE
Middleware fix for released jobs

### DIFF
--- a/src/Jobs/Middleware/TrackedJobMiddleware.php
+++ b/src/Jobs/Middleware/TrackedJobMiddleware.php
@@ -10,12 +10,14 @@ class TrackedJobMiddleware
     {
         $job->trackedJob->markAsStarted();
 
-        try {
-            $response = $next($job);
+        $response = $next($job);
 
+        if ($job->job->isReleased())
+        {
+            $job->trackedJob->markAsRetrying();
+        }
+        else {
             $job->trackedJob->markAsFinished($response);
-        } catch (Throwable $exception) {
-            $job->fail($exception);
         }
     }
 }

--- a/src/Models/TrackedJob.php
+++ b/src/Models/TrackedJob.php
@@ -33,12 +33,14 @@ class TrackedJob extends Model implements TrackableJobContract
     use Prunable;
 
     const STATUS_QUEUED = 'queued';
+    const STATUS_RETRYING = 'retrying';
     const STATUS_STARTED = 'started';
     const STATUS_FINISHED = 'finished';
     const STATUS_FAILED = 'failed';
 
     const STATUSES = [
         self::STATUS_QUEUED,
+        self::STATUS_RETRYING,
         self::STATUS_STARTED,
         self::STATUS_FINISHED,
         self::STATUS_FAILED,
@@ -94,6 +96,20 @@ class TrackedJob extends Model implements TrackableJobContract
         return $this->update([
             'status' => static::STATUS_STARTED,
             'started_at' => now(),
+        ]);
+    }
+
+    public function markAsQueued(): bool
+    {
+        return $this->update([
+            'status' => static::STATUS_QUEUED,
+        ]);
+    }
+
+    public function markAsRetrying(): bool
+    {
+        return $this->update([
+            'status' => static::STATUS_RETRYING,
         ]);
     }
 


### PR DESCRIPTION
Regarding: https://github.com/mateusjunges/trackable-jobs-for-laravel/issues/35

Fix for: Jobs which get released back into the queue are getting marked as finished instead of "retrying".

Retrying status makes more sense here as setting the jobs as "queued" will be confusing.
This will indicate that the job has been tried already. 

The method `markAsQueued` was still added to the model as there are scenarios where it's useful to have this method if creating custom/additional  middleware for this package.

`started_at` is not set to null to to display when the job was started last time. 