### PR TITLE
fix: publish the migration which adds the queue column

### DIFF
--- a/src/Providers/TrackableJobsServiceProvider.php
+++ b/src/Providers/TrackableJobsServiceProvider.php
@@ -17,8 +17,11 @@ class TrackableJobsServiceProvider extends ServiceProvider
             __DIR__.'/../../config/trackable-jobs.php' => config_path('trackable-jobs.php'),
         ], 'trackable-jobs-assets');
 
+        $publishedAt = time();
+
         $this->publishes([
-            __DIR__.'/../../database/migrations/laravel_trackable_create_tracked_jobs_table.php' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_tracked_jobs_table.php'),
+            __DIR__.'/../../database/migrations/laravel_trackable_create_tracked_jobs_table.php' => database_path('migrations/'.date('Y_m_d_His', $publishedAt).'_create_tracked_jobs_table.php'),
+            __DIR__.'/../../database/migrations/add_queue_column_to_tracked_jobs_table.php' => database_path('migrations/'.date('Y_m_d_His', $publishedAt + 1).'_add_queue_column_to_tracked_jobs_table.php'),
         ], 'trackable-jobs-assets');
 
         Event::listen(JobQueued::class, UpdateTrackedJobStatus::class);


### PR DESCRIPTION
upgrading to v3 results in the queue column migration not being published therefore resulting in crashes when trying to add jobs to the tracked table this pr fixes that by publishing the migration